### PR TITLE
Update Files.swift

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -1021,7 +1021,7 @@ private extension FileManager {
             return nil
         }
 
-        if objCBool.boolValue {
+        if objCBool {
             return .folder
         }
         


### PR DESCRIPTION
Fixes 

```
/home/luis/.marathon/Scripts/Cache/-tmp-teste/.build/checkouts/Files.git--6062313482316197225/Sources/Files.swift:1024:12: error: value of type 'Bool' has no member 'boolValue'
           if objCBool.boolValue {
              ^~~~~~~~ ~~~~~~~~~
```
In Swift version 4.0.3 (swift-4.0.3-RELEASE)